### PR TITLE
add build.yml for CI CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: zephyrprojectrtos/ci:latest
+    env:
+      CMAKE_PREFIX_PATH: /opt/toolchains
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: Arduino-Zephyr-API
+
+      - name: Initialize
+        working-directory: Arduino-Zephyr-API
+        run: |
+          west init -m https://github.com/DhruvaG2000/arduino-core-testing.git
+          west update
+          git clone https://github.com/arduino/ArduinoCore-API.git ArduinoCore-API
+          sed '/WCharacter.h/ s/./\/\/ &/' ArduinoCore-API/api/ArduinoAPI.h > ArduinoCore-API/api/tmpArduinoAPI.h
+          mv ArduinoCore-API/api/tmpArduinoAPI.h ArduinoCore-API/api/ArduinoAPI.h
+          cp -r ArduinoCore-API/api /__w/arduino-core-testing/arduino-core-testing/Arduino-Zephyr-API/modules/lib/Arduino-Zephyr-API/cores/arduino/.
+
+      - name: Build fade
+        working-directory: Arduino-Zephyr-API
+        run: |
+          west build -p -b arduino_nano_33_ble_sense samples/fade
+
+      - name: Build i2cdemo
+        working-directory: Arduino-Zephyr-API
+        run: |
+          west build -p -b arduino_nano_33_ble_sense samples/i2cdemo
+
+      - name: Archive firmware
+        uses: actions/upload-artifact@v2
+        with:
+          name: firmware
+          path: Arduino-Zephyr-API/build/zephyr/zephyr.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Copyright (c) 2022 Dhruva Gole <goledhruva@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+FROM zephyrprojectrtos/ci:latest AS base
+
+RUN \
+  west init -m https://github.com/zephyrproject-rtos/gsoc-2022-arduino-core.git && west update \
+  && git clone https://github.com/arduino/ArduinoCore-API.git ArduinoCore-API \
+  && sed '/WCharacter.h/ s/./\/\/ &/' ArduinoCore-API/api/ArduinoAPI.h > ArduinoCore-API/api/tmpArduinoAPI.h \
+  && mv ArduinoCore-API/api/tmpArduinoAPI.h ArduinoCore-API/api/ArduinoAPI.h \
+  && cp -r /ArduinoCore-API/api /modules/lib/Arduino-Zephyr-API/cores/arduino/. \
+  && cd modules/lib/Arduino-Zephyr-API && ls -la \
+  && west build -p -b arduino_nano_33_ble samples/blinky_arduino \
+  && printf '%s\n' "Module Successfully setup and built..."

--- a/west.yml
+++ b/west.yml
@@ -1,0 +1,19 @@
+# Copyright (c) 2022 Dhruva Gole <goledhruva@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+# NOTE: This is created to be used for CI/CD workflow. So use it only
+# if you are in the zephyrproject directory or else things may break.
+
+manifest:
+  self:
+    path: modules/lib/Arduino-Zephyr-API
+
+  remotes:
+    - name: zephyrproject-rtos
+      url-base: https://github.com/zephyrproject-rtos
+
+  projects:
+    - name: zephyr
+      remote: zephyrproject-rtos
+      revision: main
+      import: true


### PR DESCRIPTION
This creates a CI CD build workflow to check if project builds successfully for a basic blink led sample

Signed-off-by: Dhruva Gole <goledhruva@gmail.com>